### PR TITLE
Preserve exit code in bash hook

### DIFF
--- a/fasd
+++ b/fasd
@@ -125,8 +125,11 @@ EOS
 
       bash-hook) cat <<EOS
 _fasd_prompt_func() {
+  local _exit_code="\$?"
   eval "fasd --proc \$(fasd --sanitize \$(history 1 | \\
     sed "s/^[ ]*[0-9]*[ ]*//"))" >> "$_FASD_SINK" 2>&1
+  # preserve exit code
+  return \$_exit_code
 }
 
 # add bash hook


### PR DESCRIPTION
Preserve the exit code from the previous command the user ran when
exiting from the bash hook. This allows other commands in
PROMPT_COMMAND to handle the exit code from the original user command.